### PR TITLE
Implement FansET auth experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
-# FansET — Fansly-Style OnlyFans Clone Boilerplate
+# FansET — Creator subscription platform starter
 
-A monorepo starter kit for building an OnlyFans-style experience with a modern, mobile-first React frontend, an Express/Node.js API layer, and MongoDB-ready database utilities. All UI screens are inspired by the supplied reference screenshots, including a dark landing page, feed, profile, notifications, collections, messages, and billing flows.
+FansET is a full-stack starter kit for building a modern creator subscription experience. The Vite + React frontend ships with a
+Fansly-inspired interface restyled for the FansET brand, while the Express backend exposes real authentication endpoints,
+creator discovery data, and Mongo-ready database utilities.
 
 ## Repository structure
 
 ```
 .
-├── frontend/        # Vite + React single-page app with mock data and static routes
-│   ├── public/
-│   ├── src/
-│   │   ├── components/   # Sidebar, Header, cards, shared form elements
-│   │   ├── data/         # Mock creators, posts, collections, transactions
-│   │   └── pages/        # Landing, Home, Profile, Messages, Collections, Add Card, Notifications
-├── backend/         # Express server boilerplate with sample routes
+├── frontend/        # React single-page application powered by Vite
+│   ├── src/components/   # Sidebar, Header, PostCard, shared form elements and route guards
+│   ├── src/context/      # Auth provider with JWT-aware session persistence
+│   ├── src/pages/        # Landing, Home, Profile, Messages, Collections, Billing, Notifications
+│   ├── src/services/     # API client used across the app
+│   └── src/data/         # Fallback content used when the API is offline
+├── backend/         # Express server with JWT auth routes and content endpoints
 │   └── src/
-│       ├── routes/      # API routing examples returning mock data
-│       └── server.js    # App bootstrap with security middleware
-├── database/        # Mongo/Mongoose connection helpers
-├── .gitignore
+│       ├── controllers/  # Auth + content handlers
+│       ├── middleware/   # JWT verification middleware
+│       ├── models/       # Mongoose user schema
+│       └── routes/       # API router composition
+├── database/        # MongoDB connection helpers
 └── README.md
 ```
 
@@ -28,16 +31,22 @@ A monorepo starter kit for building an OnlyFans-style experience with a modern, 
    cd frontend
    npm install
    ```
-2. Start the development server:
+2. (Optional) point the SPA at a different API host by creating a `.env` file with `VITE_API_BASE_URL`. The default is
+   `http://localhost:5000/api`.
+3. Start the development server:
    ```bash
    npm run dev
    ```
-3. Build for production:
+4. Build for production:
    ```bash
    npm run build
    ```
 
-The React SPA is configured with React Router (`App.js`) and includes reusable components (`Sidebar`, `Header`, `PostCard`, `CreatorCard`, `FormInput`). Pages reflect the requested UI layouts, with mock data living in `src/data/mockData.js`. All forms include age-confirmation checkboxes, and footer legal links appear on every internal screen.
+Key features:
+- Landing page now ships with a FansET branded signup/login panel wired to the backend authentication endpoints.
+- Auth state is provided via `AuthContext`, persisted in `localStorage`, and consumed through a `useAuth` hook.
+- App routes beyond the landing screen are protected with `ProtectedRoute` and only render for authenticated users.
+- Home feed fetches creators and posts from the backend with graceful fallbacks to the mock data bundle when offline.
 
 ## Backend (Node.js + Express)
 
@@ -46,7 +55,13 @@ The React SPA is configured with React Router (`App.js`) and includes reusable c
    cd backend
    npm install
    ```
-2. Configure environment (optional) by creating a `.env` file with `PORT` and `MONGODB_URI` if you need to override defaults.
+2. Create a `.env` file (optional) to override defaults:
+   ```env
+   PORT=5000
+   MONGODB_URI=mongodb://localhost:27017/fanset
+   JWT_SECRET=super-secret-token
+   JWT_EXPIRES_IN=7d
+   ```
 3. Run in development mode with hot reloading:
    ```bash
    npm run dev
@@ -56,23 +71,35 @@ The React SPA is configured with React Router (`App.js`) and includes reusable c
    npm start
    ```
 
-The API exposes mock `/api/creators` and `/api/posts` endpoints. Security middleware (Helmet, CORS) and request logging (Morgan) are pre-wired. Database connectivity is deferred to the shared `database/connection.js` utility which targets MongoDB via Mongoose.
+### API overview
+
+| Method | Endpoint          | Description                                    |
+| ------ | ----------------- | ---------------------------------------------- |
+| POST   | `/api/auth/register` | Create a new account, returning a JWT + profile |
+| POST   | `/api/auth/login`    | Sign in with email/username + password        |
+| GET    | `/api/auth/me`       | Fetch the authenticated user (requires token) |
+| GET    | `/api/creators`      | Discover featured FansET creators             |
+| GET    | `/api/posts`         | Pull the curated FansET home feed             |
+
+All authenticated requests expect a `Bearer <token>` header. Passwords are hashed with `bcryptjs` and JWTs are signed with the
+configurable `JWT_SECRET`.
 
 ## Database utilities
 
-The `database/connection.js` module provides `connectDatabase` and `disconnectDatabase` helpers with sane defaults (`mongodb://localhost:27017/fansly_clone`). Adjust the URI in your environment variables as needed.
+`database/connection.js` exposes `connectDatabase` and `disconnectDatabase` helpers. By default the API targets
+`mongodb://localhost:27017/fanset`. Update `MONGODB_URI` in your environment to point at another instance.
 
 ## Testing & linting
 
-* Frontend lint: `cd frontend && npm run lint`
-* Backend lint: `cd backend && npm run lint`
+- Frontend lint: `cd frontend && npm run lint`
+- Backend lint: `cd backend && npm run lint`
 
-No automated tests are bundled, but the directory structure is ready for Jest, Vitest, Supertest, or Cypress should you decide to extend the stack.
+## Design tokens & accessibility
 
-## Assets & accessibility
+- Primary palette: FansET blue (`#00A3FF`), emerald accents (`#22C55E`), deep night background (`#020617`).
+- Landing layout embraces large typography, glassmorphism panels, and high-contrast CTAs.
+- Components include descriptive aria labels, keyboard-friendly controls, and minimum 18+ confirmation checkboxes where
+  required.
 
-* Color palette: Fansly blue (`#00A3FF`), green accents (`#22C55E`), white/light gray surfaces, dark landing hero (`#000000`).
-* Mobile-first design with responsive breakpoints and flex/grid layouts for all pages.
-* Semantic headings, descriptive alt text, and focus-friendly controls across the mock UI.
-
-> **Disclaimer:** This boilerplate ships with static/mock data only. No real authentication, billing, or streaming integrations are active.
+> **Disclaimer:** No real billing or streaming integrations are present. The stack focuses on auth, layout, and data flow
+plumbing so you can extend it to production use cases.

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -8,5 +8,7 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "rules": {}
+  "rules": {
+    "semi": ["error", "always"]
+  }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "fansly-clone-backend",
+  "name": "fanset-backend",
   "version": "1.0.0",
-  "description": "Express API boilerplate for a Fansly-style OnlyFans clone.",
+  "description": "Express API server for the FansET platform.",
   "main": "src/server.js",
   "type": "module",
   "scripts": {
@@ -10,6 +10,7 @@
     "lint": "eslint src --ext js"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^16.4.0",
     "express": "^4.18.3",

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,0 +1,123 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import User from '../models/User.js';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'change-me-in-production';
+const JWT_EXPIRY = process.env.JWT_EXPIRES_IN || '7d';
+
+const createToken = (userId) =>
+  jwt.sign(
+    {
+      sub: userId
+    },
+    JWT_SECRET,
+    { expiresIn: JWT_EXPIRY }
+  );
+
+const normalizeEmail = (value = '') => value.trim().toLowerCase();
+const normalizeUsername = (value = '') => value.trim().toLowerCase();
+
+const sanitizeUser = (user) => user.toSafeObject();
+
+export const register = async (req, res) => {
+  try {
+    const { email, username, displayName, password, avatarUrl, bio } = req.body ?? {};
+
+    if (!email || !username || !displayName || !password) {
+      return res.status(400).json({ error: 'Email, username, display name and password are required.' });
+    }
+
+    if (password.length < 8) {
+      return res.status(400).json({ error: 'Password must be at least 8 characters long.' });
+    }
+
+    const normalizedEmail = normalizeEmail(email);
+    const normalizedUsername = normalizeUsername(username);
+
+    const existingUser = await User.findOne({
+      $or: [{ email: normalizedEmail }, { username: normalizedUsername }]
+    });
+
+    if (existingUser) {
+      return res.status(409).json({ error: 'An account with that email or username already exists.' });
+    }
+
+    const passwordHash = await bcrypt.hash(password, 12);
+
+    const user = await User.create({
+      email: normalizedEmail,
+      username: normalizedUsername,
+      displayName: displayName.trim(),
+      passwordHash,
+      avatarUrl: avatarUrl?.trim() ?? '',
+      bio: bio?.trim() ?? ''
+    });
+
+    const token = createToken(user.id);
+
+    return res.status(201).json({
+      user: sanitizeUser(user),
+      token
+    });
+  } catch (error) {
+    console.error('Failed to register user', error);
+    if (error?.code === 11000) {
+      return res.status(409).json({ error: 'That email or username is already registered.' });
+    }
+    if (error?.name === 'ValidationError') {
+      return res.status(400).json({ error: 'Please double-check your details and try again.' });
+    }
+    return res.status(500).json({ error: 'Unable to create account at this time.' });
+  }
+};
+
+export const login = async (req, res) => {
+  try {
+    const { identifier, password } = req.body ?? {};
+
+    if (!identifier || !password) {
+      return res.status(400).json({ error: 'Identifier and password are required.' });
+    }
+
+    const query = identifier.includes('@')
+      ? { email: normalizeEmail(identifier) }
+      : { username: normalizeUsername(identifier) };
+
+    const user = await User.findOne(query);
+
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid credentials.' });
+    }
+
+    const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
+
+    if (!isPasswordValid) {
+      return res.status(401).json({ error: 'Invalid credentials.' });
+    }
+
+    const token = createToken(user.id);
+
+    return res.json({
+      user: sanitizeUser(user),
+      token
+    });
+  } catch (error) {
+    console.error('Failed to authenticate user', error);
+    return res.status(500).json({ error: 'Unable to sign in at this time.' });
+  }
+};
+
+export const getCurrentUser = async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id);
+
+    if (!user) {
+      return res.status(404).json({ error: 'User not found.' });
+    }
+
+    return res.json({ user: sanitizeUser(user) });
+  } catch (error) {
+    console.error('Failed to fetch current user', error);
+    return res.status(500).json({ error: 'Unable to load account details.' });
+  }
+};

--- a/backend/src/controllers/contentController.js
+++ b/backend/src/controllers/contentController.js
@@ -1,4 +1,37 @@
-export const posts = [
+const DEFAULT_CREATORS = [
+  {
+    id: 'creator-nova-kai',
+    name: 'Nova Kai',
+    handle: 'novakai',
+    price: 'Free',
+    image:
+      'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=600&q=80',
+    isVerified: true,
+    categories: ['VR fitness', 'Livestreams']
+  },
+  {
+    id: 'creator-elysian-tide',
+    name: 'Elysian Tide',
+    handle: 'elysiantide',
+    price: '$12.99',
+    image:
+      'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=600&q=80',
+    isVerified: true,
+    categories: ['Underwater sets', 'Cinema edits']
+  },
+  {
+    id: 'creator-zen',
+    name: 'Zen Haru',
+    handle: 'zenharu',
+    price: '$7.50',
+    image:
+      'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=600&q=80',
+    isVerified: false,
+    categories: ['Meditation', 'Q&A']
+  }
+];
+
+const DEFAULT_POSTS = [
   {
     id: 'post-aurora-studio',
     author: 'Aurora Skye',
@@ -40,45 +73,10 @@ export const posts = [
   }
 ];
 
-export const creators = [
-  {
-    id: 'creator-nova-kai',
-    name: 'Nova Kai',
-    handle: 'novakai',
-    price: 'Free',
-    image:
-      'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=600&q=80',
-    isVerified: true
-  },
-  {
-    id: 'creator-elysian-tide',
-    name: 'Elysian Tide',
-    handle: 'elysiantide',
-    price: '$12.99',
-    image:
-      'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=600&q=80',
-    isVerified: true
-  },
-  {
-    id: 'creator-zen',
-    name: 'Zen Haru',
-    handle: 'zenharu',
-    price: '$7.50',
-    image:
-      'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=600&q=80',
-    isVerified: false
-  }
-];
+export const listCreators = (_req, res) => {
+  res.json({ creators: DEFAULT_CREATORS });
+};
 
-export const collections = [
-  {
-    id: 'list-holographic-dreams',
-    name: 'Holographic Dreams',
-    users: 312,
-    posts: 18,
-    cover:
-      'https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=200&q=80'
-  }
-];
-
-export const transactions = [];
+export const listPosts = (_req, res) => {
+  res.json({ posts: DEFAULT_POSTS });
+};

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,35 @@
+import jwt from 'jsonwebtoken';
+import User from '../models/User.js';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'change-me-in-production';
+
+const auth = async (req, res, next) => {
+  const authorizationHeader = req.headers.authorization || '';
+
+  const [scheme, rawToken] = authorizationHeader.split(' ');
+
+  if (scheme?.toLowerCase() !== 'bearer' || !rawToken) {
+    return res.status(401).json({ error: 'Authentication required.' });
+  }
+
+  const token = rawToken.trim();
+
+  try {
+    const payload = jwt.verify(token, JWT_SECRET);
+
+    const user = await User.findById(payload.sub);
+
+    if (!user) {
+      return res.status(401).json({ error: 'Authentication required.' });
+    }
+
+    req.user = { id: user.id };
+
+    return next();
+  } catch (error) {
+    console.error('Failed to verify token', error);
+    return res.status(401).json({ error: 'Invalid or expired token.' });
+  }
+};
+
+export default auth;

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,0 +1,61 @@
+import mongoose from 'mongoose';
+
+const userSchema = new mongoose.Schema(
+  {
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true
+    },
+    username: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+      minlength: 3
+    },
+    displayName: {
+      type: String,
+      required: true,
+      trim: true,
+      minlength: 2
+    },
+    passwordHash: {
+      type: String,
+      required: true
+    },
+    avatarUrl: {
+      type: String,
+      default: ''
+    },
+    bio: {
+      type: String,
+      default: ''
+    }
+  },
+  {
+    timestamps: true
+  }
+);
+
+userSchema.methods.toSafeObject = function toSafeObject () {
+  const { _id, email, username, displayName, avatarUrl, bio, createdAt, updatedAt } = this;
+
+  return {
+    id: _id.toString(),
+    email,
+    username,
+    displayName,
+    avatarUrl,
+    bio,
+    createdAt,
+    updatedAt
+  };
+};
+
+const User = mongoose.models.User || mongoose.model('User', userSchema);
+
+export default User;

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { getCurrentUser, login, register } from '../controllers/authController.js';
+import auth from '../middleware/auth.js';
+
+const router = Router();
+
+router.post('/register', register);
+router.post('/login', login);
+router.get('/me', auth, getCurrentUser);
+
+export default router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,28 +1,16 @@
 import { Router } from 'express';
+import { listCreators, listPosts } from '../controllers/contentController.js';
+import authRoutes from './authRoutes.js';
 
 const router = Router();
 
 router.get('/health', (_req, res) => {
-  res.json({ ok: true, timestamp: new Date().toISOString() });
+  res.json({ ok: true, service: 'fanset-api', timestamp: new Date().toISOString() });
 });
 
-router.get('/creators', (_req, res) => {
-  res.json([
-    { id: 'creator-1', name: 'Josephine Blush', handle: 'josephineb', price: 'Free' },
-    { id: 'creator-2', name: 'MaryLover', handle: 'marylover', price: 'Free' },
-    { id: 'creator-3', name: 'Your Wife', handle: 'your_wife', price: 'Free' }
-  ]);
-});
+router.use('/auth', authRoutes);
 
-router.get('/posts', (_req, res) => {
-  res.json([
-    {
-      id: 'post-1',
-      author: '@onlyfans',
-      content:
-        'Ready for a forest adventure? Join @nyxx at night in Sequoia National Park, where giant trees and the beauty of nature come to life through her lens.'
-    }
-  ]);
-});
+router.get('/creators', listCreators);
+router.get('/posts', listPosts);
 
 export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,7 +16,7 @@ app.use(express.json());
 app.use(morgan('dev'));
 
 app.get('/', (_req, res) => {
-  res.json({ status: 'Fansly clone API is running' });
+  res.json({ status: 'FansET API is running' });
 });
 
 app.use('/api', router);

--- a/database/connection.js
+++ b/database/connection.js
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 
-const defaultUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/fansly_clone';
+const defaultUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/fanset';
 
 export const connectDatabase = async () => {
   if (!mongoose.connection.readyState) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fansly Clone</title>
+    <title>FansET</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "fansly-clone-frontend",
+  "name": "fanset-frontend",
   "version": "1.0.0",
   "private": true,
-  "description": "Mobile-first React frontend for a Fansly-style OnlyFans clone.",
+  "description": "Mobile-first React frontend for the FansET platform.",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -17,6 +17,15 @@
   width: 100%;
 }
 
+.route-guard__loading {
+  display: grid;
+  place-items: center;
+  min-height: 50vh;
+  color: var(--fanset-dark);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
 @media (max-width: 1024px) {
   .app-layout {
     flex-direction: column;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import MessagesPage from './pages/MessagesPage';
 import CollectionsPage from './pages/CollectionsPage';
 import AddCardPage from './pages/AddCardPage';
 import NotificationsPage from './pages/NotificationsPage';
+import ProtectedRoute from './components/ProtectedRoute.jsx';
 import './App.css';
 
 const AppLayout = ({ children }) => (
@@ -23,49 +24,61 @@ const App = () => (
     <Route
       path="/home"
       element={(
-        <AppLayout>
-          <HomePage />
-        </AppLayout>
+        <ProtectedRoute>
+          <AppLayout>
+            <HomePage />
+          </AppLayout>
+        </ProtectedRoute>
       )}
     />
     <Route
       path="/profile"
       element={(
-        <AppLayout>
-          <ProfilePage />
-        </AppLayout>
+        <ProtectedRoute>
+          <AppLayout>
+            <ProfilePage />
+          </AppLayout>
+        </ProtectedRoute>
       )}
     />
     <Route
       path="/messages"
       element={(
-        <AppLayout>
-          <MessagesPage />
-        </AppLayout>
+        <ProtectedRoute>
+          <AppLayout>
+            <MessagesPage />
+          </AppLayout>
+        </ProtectedRoute>
       )}
     />
     <Route
       path="/collections"
       element={(
-        <AppLayout>
-          <CollectionsPage />
-        </AppLayout>
+        <ProtectedRoute>
+          <AppLayout>
+            <CollectionsPage />
+          </AppLayout>
+        </ProtectedRoute>
       )}
     />
     <Route
       path="/add-card"
       element={(
-        <AppLayout>
-          <AddCardPage />
-        </AppLayout>
+        <ProtectedRoute>
+          <AppLayout>
+            <AddCardPage />
+          </AppLayout>
+        </ProtectedRoute>
       )}
     />
     <Route
       path="/notifications"
       element={(
-        <AppLayout>
-          <NotificationsPage />
-        </AppLayout>
+        <ProtectedRoute>
+          <AppLayout>
+            <NotificationsPage />
+          </AppLayout>
+        </ProtectedRoute>
       )}
     />
     <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/CreatorCard.css
+++ b/frontend/src/components/CreatorCard.css
@@ -27,7 +27,7 @@
   position: absolute;
   top: 0.5rem;
   right: 0.5rem;
-  background-color: var(--fansly-blue);
+  background-color: var(--fanset-blue);
   color: #ffffff;
   font-size: 0.75rem;
   padding: 0.25rem;
@@ -55,7 +55,7 @@
 
 .creator-card__price {
   font-weight: 600;
-  color: var(--fansly-green);
+  color: var(--fanset-green);
 }
 
 .creator-card__actions {
@@ -73,11 +73,11 @@
 }
 
 .creator-card__primary {
-  background: linear-gradient(135deg, var(--fansly-blue), #38bdf8);
+  background: linear-gradient(135deg, var(--fanset-blue), #38bdf8);
   color: #ffffff;
 }
 
 .creator-card__secondary {
   background-color: rgba(34, 197, 94, 0.1);
-  color: var(--fansly-green);
+  color: var(--fanset-green);
 }

--- a/frontend/src/components/FormInput.css
+++ b/frontend/src/components/FormInput.css
@@ -3,11 +3,12 @@
   flex-direction: column;
   gap: 0.4rem;
   font-size: 0.9rem;
-  color: #1f2937;
+  color: inherit;
 }
 
 .form-input__label {
   font-weight: 600;
+  color: inherit;
 }
 
 .form-input input,
@@ -21,6 +22,6 @@
 }
 
 .form-input__hint {
-  color: #64748b;
+  color: rgba(148, 163, 184, 0.9);
   font-size: 0.75rem;
 }

--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -39,7 +39,7 @@
   gap: 0.5rem;
   padding: 0.65rem 1rem;
   border-radius: 999px;
-  border: 1px solid var(--fansly-border);
+  border: 1px solid var(--fanset-border);
   width: min(460px, 100%);
   background-color: #f8fafc;
 }
@@ -60,7 +60,7 @@
 .page-header__search-suffix {
   border: none;
   background: transparent;
-  color: var(--fansly-blue);
+  color: var(--fanset-blue);
   font-size: 1rem;
 }
 

--- a/frontend/src/components/PostCard.css
+++ b/frontend/src/components/PostCard.css
@@ -15,11 +15,36 @@
   gap: 0.75rem;
 }
 
+.post-card__author {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: #0f172a;
+}
+
+.post-card__author strong {
+  font-size: 1rem;
+}
+
+.post-card__meta {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.post-card__handle {
+  color: var(--fanset-blue);
+  font-weight: 600;
+}
+
 .post-card__avatar {
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #1d4ed8, var(--fansly-blue));
+  background: linear-gradient(135deg, #1d4ed8, var(--fanset-blue));
   color: #ffffff;
   display: grid;
   place-items: center;
@@ -31,7 +56,7 @@
   padding: 0.5rem 1rem;
   border-radius: 999px;
   border: none;
-  background: linear-gradient(135deg, var(--fansly-green), #4ade80);
+  background: linear-gradient(135deg, var(--fanset-green), #4ade80);
   color: #ffffff;
   font-weight: 600;
 }

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -1,41 +1,72 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import './PostCard.css';
 
-const PostCard = ({ post }) => (
-  <article className="post-card">
-    <header className="post-card__header">
-      <div className="post-card__avatar" aria-label={`${post.author} avatar`}>
-        {post.initials}
-      </div>
-      <div>
-        <strong>{post.author}</strong>
-        <p className="post-card__meta">{post.timeAgo}</p>
-      </div>
-      <button type="button" className="post-card__follow">
-        Follow
-      </button>
-    </header>
-    <p className="post-card__content">{post.content}</p>
-    {post.image && (
-      <div className="post-card__image">
-        <img src={post.image} alt={post.imageAlt} />
-        {post.imageCaption && <span>{post.imageCaption}</span>}
-      </div>
-    )}
-    <footer className="post-card__footer">
-      <button type="button">❤️ 2.1k</button>
-      <button type="button">💬 245</button>
-      <button type="button">🔁 Share</button>
-      <button type="button">🔖 Save</button>
-    </footer>
-  </article>
-);
+const getInitials = (name, handle) => {
+  if (name) {
+    const letters = name
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((part) => part[0]?.toUpperCase() ?? '')
+      .join('');
+
+    if (letters) {
+      return letters.slice(0, 2);
+    }
+  }
+
+  if (handle) {
+    const trimmed = handle.replace('@', '').trim();
+    if (trimmed.length >= 2) {
+      return trimmed.slice(0, 2).toUpperCase();
+    }
+  }
+
+  return 'FE';
+};
+
+const PostCard = ({ post }) => {
+  const initials = useMemo(() => post.initials || getInitials(post.author, post.handle), [post.author, post.handle, post.initials]);
+
+  return (
+    <article className="post-card">
+      <header className="post-card__header">
+        <div className="post-card__avatar" aria-label={`${post.author} avatar`}>
+          {initials}
+        </div>
+        <div className="post-card__author">
+          <strong>{post.author}</strong>
+          <p className="post-card__meta">
+            {post.handle && <span className="post-card__handle">{post.handle}</span>}
+            <span>{post.timeAgo}</span>
+          </p>
+        </div>
+        <button type="button" className="post-card__follow">
+          Follow
+        </button>
+      </header>
+      <p className="post-card__content">{post.content}</p>
+      {post.image && (
+        <div className="post-card__image">
+          <img src={post.image} alt={post.imageAlt} />
+          {post.imageCaption && <span>{post.imageCaption}</span>}
+        </div>
+      )}
+      <footer className="post-card__footer">
+        <button type="button">❤️ 2.1k</button>
+        <button type="button">💬 245</button>
+        <button type="button">🔁 Share</button>
+        <button type="button">🔖 Save</button>
+      </footer>
+    </article>
+  );
+};
 
 PostCard.propTypes = {
   post: PropTypes.shape({
     author: PropTypes.string.isRequired,
-    initials: PropTypes.string.isRequired,
+    handle: PropTypes.string,
+    initials: PropTypes.string,
     content: PropTypes.string.isRequired,
     image: PropTypes.string,
     imageAlt: PropTypes.string,

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Navigate } from 'react-router-dom';
+import useAuth from '../hooks/useAuth.js';
+
+const ProtectedRoute = ({ children }) => {
+  const { user, initializing } = useAuth();
+
+  if (initializing) {
+    return (
+      <div className="route-guard__loading" role="status" aria-live="polite">
+        Loading your FansET experience...
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+};
+
+ProtectedRoute.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+export default ProtectedRoute;

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -5,7 +5,7 @@
   justify-content: space-between;
   padding: 1.5rem 1rem;
   background-color: #ffffff;
-  border-right: 1px solid var(--fansly-border);
+  border-right: 1px solid var(--fanset-border);
   box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
   position: sticky;
   top: 0;
@@ -21,13 +21,39 @@
   width: 64px;
   height: 64px;
   border-radius: 50%;
-  background: linear-gradient(145deg, var(--fansly-blue), #4cc7ff);
+  background: linear-gradient(145deg, var(--fanset-blue), #4cc7ff);
   color: #ffffff;
   font-weight: 700;
   font-size: 1.5rem;
   display: grid;
   place-items: center;
   margin: 0 auto 1.5rem;
+}
+
+.sidebar__user {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 1.5rem;
+  color: #1f2937;
+}
+
+.sidebar__user strong {
+  font-size: 1rem;
+}
+
+.sidebar__user span {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.sidebar--dark .sidebar__user {
+  color: #f1f5f9;
+}
+
+.sidebar--dark .sidebar__user span {
+  color: #cbd5f5;
 }
 
 .sidebar__nav {
@@ -50,12 +76,12 @@
 
 .sidebar__nav-link:hover {
   background-color: rgba(0, 163, 255, 0.12);
-  color: var(--fansly-blue);
+  color: var(--fanset-blue);
 }
 
 .sidebar__nav-link--active {
   background-color: rgba(0, 163, 255, 0.18);
-  color: var(--fansly-blue);
+  color: var(--fanset-blue);
   font-weight: 600;
 }
 
@@ -78,7 +104,7 @@
   width: 100%;
   padding: 0.85rem 1rem;
   border-radius: 999px;
-  background: linear-gradient(135deg, var(--fansly-blue), #44bfff);
+  background: linear-gradient(135deg, var(--fanset-blue), #44bfff);
   color: #ffffff;
   font-size: 0.95rem;
   font-weight: 600;
@@ -101,7 +127,7 @@
   gap: 0.5rem;
   padding: 0.65rem 1rem;
   border-radius: 0.75rem;
-  border: 1px solid var(--fansly-border);
+  border: 1px solid var(--fanset-border);
   background-color: #ffffff;
   color: #475467;
   font-weight: 500;

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import './Sidebar.css';
+import useAuth from '../hooks/useAuth.js';
 
 const navItems = [
   { to: '/home', label: 'Home', icon: '🏠' },
@@ -13,15 +14,34 @@ const navItems = [
   { to: '/more', label: 'More', icon: '⋯', disabled: true }
 ];
 
+const getInitials = (value) =>
+  value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('')
+    .slice(0, 2) || 'FE';
+
 const Sidebar = () => {
   const [darkMode, setDarkMode] = useState(false);
   const location = useLocation();
+  const { user, logout } = useAuth();
+
+  const initials = useMemo(() => (user?.displayName ? getInitials(user.displayName) : 'FE'), [user?.displayName]);
+
+  const handleLogout = () => {
+    logout();
+  };
 
   return (
     <aside className={`sidebar ${darkMode ? 'sidebar--dark' : ''}`}>
       <div className="sidebar__top">
-        <div className="sidebar__avatar" aria-label="Fansly user avatar">
-          S
+        <div className="sidebar__avatar" aria-label="FansET user avatar">
+          {initials}
+        </div>
+        <div className="sidebar__user" aria-live="polite">
+          <strong>{user?.displayName ?? 'FansET Creator'}</strong>
+          {user?.username && <span>@{user.username}</span>}
         </div>
         <nav className="sidebar__nav">
           {navItems.map((item) => (
@@ -64,7 +84,7 @@ const Sidebar = () => {
             </span>
             <span>English</span>
           </button>
-          <button type="button" className="sidebar__toggle sidebar__logout">
+          <button type="button" className="sidebar__toggle sidebar__logout" onClick={handleLogout}>
             <span role="img" aria-label="logout">
               🚪
             </span>

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,135 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { apiClient } from '../services/apiClient.js';
+
+const AUTH_STORAGE_KEY = 'fanset.auth';
+
+const AuthContext = createContext(undefined);
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [token, setToken] = useState(null);
+  const [initializing, setInitializing] = useState(true);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
+
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+
+        if (parsed?.token && parsed?.user) {
+          setToken(parsed.token);
+          setUser(parsed.user);
+        }
+      } catch (error) {
+        console.warn('Unable to restore persisted session', error);
+        localStorage.removeItem(AUTH_STORAGE_KEY);
+      }
+    }
+
+    setInitializing(false);
+  }, []);
+
+  const persistSession = useCallback((sessionToken, sessionUser) => {
+    setToken(sessionToken);
+    setUser(sessionUser);
+    localStorage.setItem(
+      AUTH_STORAGE_KEY,
+      JSON.stringify({
+        token: sessionToken,
+        user: sessionUser
+      })
+    );
+  }, []);
+
+  const clearSession = useCallback(() => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem(AUTH_STORAGE_KEY);
+  }, []);
+
+  const signup = useCallback(
+    async (payload) => {
+      const response = await apiClient('/auth/register', {
+        method: 'POST',
+        data: payload
+      });
+
+      if (response?.token && response?.user) {
+        persistSession(response.token, response.user);
+      }
+
+      return response?.user ?? null;
+    },
+    [persistSession]
+  );
+
+  const login = useCallback(
+    async (payload) => {
+      const response = await apiClient('/auth/login', {
+        method: 'POST',
+        data: payload
+      });
+
+      if (response?.token && response?.user) {
+        persistSession(response.token, response.user);
+      }
+
+      return response?.user ?? null;
+    },
+    [persistSession]
+  );
+
+  const refreshProfile = useCallback(async () => {
+    if (!token) {
+      return null;
+    }
+
+    const response = await apiClient('/auth/me', {
+      token
+    });
+
+    if (response?.user) {
+      persistSession(token, response.user);
+      return response.user;
+    }
+
+    return null;
+  }, [persistSession, token]);
+
+  const logout = useCallback(() => {
+    clearSession();
+  }, [clearSession]);
+
+  const value = useMemo(
+    () => ({
+      user,
+      token,
+      initializing,
+      signup,
+      login,
+      logout,
+      refreshProfile
+    }),
+    [initializing, login, logout, refreshProfile, signup, token, user]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+export const useAuthContext = () => {
+  const context = useContext(AuthContext);
+
+  if (context === undefined) {
+    throw new Error('useAuthContext must be used within an AuthProvider');
+  }
+
+  return context;
+};
+
+export default AuthContext;

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,0 +1,5 @@
+import { useAuthContext } from '../context/AuthContext.jsx';
+
+const useAuth = () => useAuthContext();
+
+export default useAuth;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,12 +5,12 @@
   line-height: 1.5;
   font-weight: 400;
 
-  --fansly-blue: #00a3ff;
-  --fansly-blue-dark: #0082cc;
-  --fansly-green: #22c55e;
-  --fansly-dark: #0f172a;
-  --fansly-bg: #f1f5f9;
-  --fansly-border: #e2e8f0;
+  --fanset-blue: #00a3ff;
+  --fanset-blue-dark: #0082cc;
+  --fanset-green: #22c55e;
+  --fanset-dark: #0f172a;
+  --fanset-bg: #f1f5f9;
+  --fanset-border: #e2e8f0;
 }
 
 * {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
+import { AuthProvider } from './context/AuthContext.jsx';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/AddCardPage.css
+++ b/frontend/src/pages/AddCardPage.css
@@ -17,8 +17,8 @@
 }
 
 .add-card__tab--active {
-  border-color: var(--fansly-blue);
-  color: var(--fansly-blue);
+  border-color: var(--fanset-blue);
+  color: var(--fanset-blue);
 }
 
 .add-card__body {
@@ -98,7 +98,7 @@
   padding: 0.85rem 2rem;
   border-radius: 999px;
   border: none;
-  background: linear-gradient(135deg, var(--fansly-blue), #38bdf8);
+  background: linear-gradient(135deg, var(--fanset-blue), #38bdf8);
   color: #ffffff;
   font-weight: 700;
 }
@@ -128,7 +128,7 @@
   padding: 0.75rem 1rem;
   border-radius: 0.85rem;
   border: none;
-  background: linear-gradient(135deg, var(--fansly-blue), #38bdf8);
+  background: linear-gradient(135deg, var(--fanset-blue), #38bdf8);
   color: #ffffff;
   font-weight: 600;
 }

--- a/frontend/src/pages/CollectionsPage.css
+++ b/frontend/src/pages/CollectionsPage.css
@@ -23,8 +23,8 @@
 }
 
 .collections__tab--active {
-  border-color: var(--fansly-blue);
-  color: var(--fansly-blue);
+  border-color: var(--fanset-blue);
+  color: var(--fanset-blue);
 }
 
 .collections__search {
@@ -47,7 +47,7 @@
   border: none;
   background: transparent;
   font-size: 1.25rem;
-  color: var(--fansly-blue);
+  color: var(--fanset-blue);
 }
 
 .collections__body {

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -16,6 +16,20 @@
   gap: 1.5rem;
 }
 
+.home__status {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-radius: 0.9rem;
+  background: rgba(226, 232, 240, 0.6);
+  color: #1f2937;
+  font-weight: 500;
+}
+
+.home__status--warning {
+  background: rgba(252, 211, 77, 0.25);
+  color: #a16207;
+}
+
 .home__empty {
   text-align: center;
   padding: 2rem;

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,47 +1,111 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Header from '../components/Header';
 import PostCard from '../components/PostCard';
 import CreatorCard from '../components/CreatorCard';
-import { posts, creators } from '../data/mockData';
+import { posts as fallbackPosts, creators as fallbackCreators } from '../data/mockData';
+import { apiClient } from '../services/apiClient.js';
+import useAuth from '../hooks/useAuth.js';
 import './HomePage.css';
 
-const HomePage = () => (
-  <div className="page home">
-    <Header title="HOME" subtitle="Compose new post" searchPlaceholder="Search posts">
-      <div className="page-header__search page-header__search--wide">
-        <span aria-hidden="true">🖊️</span>
-        <input type="text" placeholder="Compose new post..." />
+const HomePage = () => {
+  const { token } = useAuth();
+  const [posts, setPosts] = useState(fallbackPosts);
+  const [creators, setCreators] = useState(fallbackCreators);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchContent = async () => {
+      try {
+        setLoading(true);
+        const [postsResponse, creatorsResponse] = await Promise.all([
+          apiClient('/posts', { token }),
+          apiClient('/creators', { token })
+        ]);
+
+        if (!isMounted) {
+          return;
+        }
+
+        if (postsResponse?.posts?.length) {
+          setPosts(postsResponse.posts);
+        } else {
+          setPosts(postsResponse?.posts ?? []);
+        }
+
+        if (creatorsResponse?.creators?.length) {
+          setCreators(creatorsResponse.creators);
+        } else {
+          setCreators(creatorsResponse?.creators ?? []);
+        }
+
+        setError('');
+      } catch (err) {
+        console.warn('Unable to load FansET feed', err);
+
+        if (!isMounted) {
+          return;
+        }
+
+        setPosts(fallbackPosts);
+        setCreators(fallbackCreators);
+        setError('Unable to reach FansET servers. Showing offline data.');
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchContent();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [token]);
+
+  return (
+    <div className="page home">
+      <Header title="HOME" subtitle="Compose new post" searchPlaceholder="Search posts">
+        <div className="page-header__search page-header__search--wide">
+          <span aria-hidden="true">🖊️</span>
+          <input type="text" placeholder="Compose new post..." />
+        </div>
+      </Header>
+      <div className="home__body">
+        <section className="home__feed">
+          {loading && <p className="home__status">Loading the latest drops…</p>}
+          {!loading && posts.length === 0 && <p className="home__empty">No posts yet.</p>}
+          {error && <p className="home__status home__status--warning">{error}</p>}
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} />
+          ))}
+          <div className="home__footer-links">
+            <a href="#">Privacy</a>
+            <a href="#">Cookie Notice</a>
+            <a href="#">Terms of Service</a>
+          </div>
+        </section>
+        <aside className="home__aside">
+          <div className="home__suggestions">
+            <div className="home__suggestions-header">
+              <h2>Suggestions</h2>
+              <button type="button" aria-label="expand suggestions">
+                ⤢
+              </button>
+            </div>
+            <div className="home__suggestions-list">
+              {creators.map((creator) => (
+                <CreatorCard key={creator.id} creator={creator} />
+              ))}
+            </div>
+          </div>
+        </aside>
       </div>
-    </Header>
-    <div className="home__body">
-      <section className="home__feed">
-        {posts.length === 0 && <p className="home__empty">No posts yet.</p>}
-        {posts.map((post) => (
-          <PostCard key={post.id} post={post} />
-        ))}
-        <div className="home__footer-links">
-          <a href="#">Privacy</a>
-          <a href="#">Cookie Notice</a>
-          <a href="#">Terms of Service</a>
-        </div>
-      </section>
-      <aside className="home__aside">
-        <div className="home__suggestions">
-          <div className="home__suggestions-header">
-            <h2>Suggestions</h2>
-            <button type="button" aria-label="expand suggestions">
-              ⤢
-            </button>
-          </div>
-          <div className="home__suggestions-list">
-            {creators.map((creator) => (
-              <CreatorCard key={creator.id} creator={creator} />
-            ))}
-          </div>
-        </div>
-      </aside>
     </div>
-  </div>
-);
+  );
+};
 
 export default HomePage;

--- a/frontend/src/pages/LandingPage.css
+++ b/frontend/src/pages/LandingPage.css
@@ -3,95 +3,134 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  background: radial-gradient(circle at top left, rgba(0, 163, 255, 0.2), transparent 45%),
-    #000000;
+  background: radial-gradient(circle at top left, rgba(0, 163, 255, 0.18), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.12), transparent 45%),
+    #020617;
   color: #f8fafc;
   padding: 2.5rem clamp(1.5rem, 5vw, 4rem);
+  gap: 3rem;
 }
 
 .landing__hero {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 3.5rem;
   align-items: start;
 }
 
 .landing__brand h1 {
-  font-size: clamp(2.5rem, 6vw, 3.75rem);
-  margin-bottom: 0.25rem;
+  font-size: clamp(2.75rem, 6vw, 3.9rem);
+  margin-bottom: 0.5rem;
 }
 
 .landing__brand p {
   font-size: 1.1rem;
-  margin-bottom: 1.5rem;
-  color: #e2e8f0;
+  margin-bottom: 1.75rem;
+  color: #cbd5f5;
+  max-width: 32rem;
 }
 
 .landing__brand ul {
   display: grid;
-  gap: 0.75rem;
+  gap: 1rem;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
 .landing__brand li {
-  font-size: 1rem;
   display: flex;
-  gap: 0.75rem;
-  align-items: center;
-  color: #cbd5f5;
+  gap: 0.85rem;
+  align-items: flex-start;
+  font-size: 1rem;
+  color: #e0f2fe;
 }
 
 .landing__brand span {
-  color: #38bdf8;
+  color: var(--fanset-blue);
+  font-size: 1.25rem;
 }
 
 .landing__logo {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.75rem;
 }
 
 .landing__form {
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.65), rgba(15, 23, 42, 0.35));
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  border-radius: 1.5rem;
-  padding: 2rem;
-  backdrop-filter: blur(12px);
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 1.75rem;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  backdrop-filter: blur(14px);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.35);
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.35);
 }
 
-.landing__actions {
+.landing__form-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.landing__form-header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.landing__tabs {
+  display: inline-flex;
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 999px;
+  padding: 0.35rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.landing__tab {
+  border: none;
+  background: transparent;
+  color: #cbd5f5;
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.landing__tab--active {
+  background: linear-gradient(135deg, var(--fanset-blue), #38bdf8);
+  color: #021018;
+}
+
+.landing__fields {
   display: grid;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .landing__button {
-  padding: 0.85rem 1.5rem;
+  padding: 0.95rem 1.5rem;
   border-radius: 999px;
   font-size: 1rem;
   font-weight: 600;
   text-align: center;
   text-decoration: none;
   border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .landing__button--primary {
-  background: linear-gradient(135deg, #00a3ff, #38bdf8);
-  color: #ffffff;
+  background: linear-gradient(135deg, var(--fanset-blue), #38bdf8);
+  color: #020617;
+  box-shadow: 0 16px 40px rgba(56, 189, 248, 0.3);
 }
 
-.landing__button--outline {
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  color: #f8fafc;
-  background: transparent;
+.landing__button--primary:disabled {
+  opacity: 0.7;
+  cursor: progress;
+  box-shadow: none;
 }
 
 .landing__social {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .landing__social-button {
@@ -99,23 +138,17 @@
   align-items: center;
   justify-content: center;
   gap: 0.75rem;
-  border-radius: 0.85rem;
+  border-radius: 0.9rem;
   border: 1px solid rgba(56, 189, 248, 0.35);
   background-color: rgba(15, 23, 42, 0.6);
   color: #e0f2fe;
-  padding: 0.75rem 1rem;
+  padding: 0.85rem 1rem;
   font-weight: 600;
 }
 
 .landing__social-button--twitch {
-  border-color: rgba(147, 51, 234, 0.45);
-  background: rgba(91, 33, 182, 0.4);
-}
-
-.landing__social-button--green {
-  border-color: rgba(34, 197, 94, 0.6);
-  background: rgba(22, 163, 74, 0.35);
-  color: #bbf7d0;
+  border-color: rgba(147, 51, 234, 0.5);
+  background: rgba(91, 33, 182, 0.45);
 }
 
 .landing__icon {
@@ -124,65 +157,40 @@
 
 .landing__checkbox {
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.85rem;
+  align-items: flex-start;
+  gap: 0.75rem;
+  font-size: 0.9rem;
   color: #cbd5e1;
 }
 
 .landing__checkbox input {
   width: 18px;
   height: 18px;
+  margin-top: 0.15rem;
 }
 
-.landing__checkbox--inline {
-  align-items: flex-start;
+.landing__status {
+  font-size: 0.95rem;
+  margin: -0.25rem 0 0;
+  color: #cbd5f5;
+}
+
+.landing__status--error {
+  color: #fca5a5;
+}
+
+.landing__status--success {
+  color: #bbf7d0;
 }
 
 .landing__fine-print {
-  font-size: 0.78rem;
+  font-size: 0.82rem;
   color: #94a3b8;
   line-height: 1.6;
 }
 
 .landing__fine-print a {
   color: #38bdf8;
-}
-
-.landing__comparison {
-  margin-top: 3rem;
-}
-
-.landing__card {
-  background: linear-gradient(135deg, #ffffff 0%, #e0f2fe 100%);
-  color: #0f172a;
-  border-radius: 1.5rem;
-  padding: 2rem;
-  display: grid;
-  gap: 1rem;
-  max-width: 520px;
-}
-
-.landing__card form {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.landing__card input {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  border-radius: 0.85rem;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-}
-
-.landing__button--ghost {
-  background-color: rgba(14, 116, 144, 0.08);
-  color: #0f172a;
-  border: 1px solid rgba(14, 165, 233, 0.35);
-}
-
-.landing__social--compact {
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 .landing__footer {
@@ -193,7 +201,6 @@
   justify-content: center;
   font-size: 0.85rem;
   color: #94a3b8;
-  margin-top: 3rem;
 }
 
 .landing__footer nav {
@@ -222,17 +229,24 @@
   border-radius: 999px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 900px) {
   .landing {
-    padding: 2rem 1.25rem;
-    gap: 2rem;
+    padding: 2rem 1.5rem;
+    gap: 2.5rem;
   }
 
   .landing__hero {
-    gap: 2rem;
+    gap: 2.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .landing__tabs {
+    width: 100%;
+    justify-content: space-between;
   }
 
-  .landing__comparison {
-    margin-top: 2rem;
+  .landing__tab {
+    flex: 1;
   }
 }

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1,123 +1,331 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import FormInput from '../components/FormInput.jsx';
+import useAuth from '../hooks/useAuth.js';
 import './LandingPage.css';
 
-const LandingPage = () => (
-  <div className="landing">
-    <div className="landing__hero">
-      <div className="landing__brand">
-        <div className="landing__logo" aria-hidden="true">
-          <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="40" cy="40" r="36" fill="#0b1622" stroke="#00a3ff" strokeWidth="8" />
-            <path
-              d="M40 50c-6-4.4-12-8.8-12-16a8 8 0 0 1 15-3.4 8 8 0 0 1 15 3.4c0 7.2-6 11.6-12 16z"
-              fill="#00a3ff"
-            />
-          </svg>
+const initialSignUpState = {
+  displayName: '',
+  username: '',
+  email: '',
+  password: '',
+  confirmPassword: '',
+  acceptTerms: true
+};
+
+const initialLoginState = {
+  identifier: '',
+  password: '',
+  acceptTerms: true
+};
+
+const LandingPage = () => {
+  const navigate = useNavigate();
+  const { signup, login, user, initializing } = useAuth();
+  const [mode, setMode] = useState('signup');
+  const [signUpForm, setSignUpForm] = useState(initialSignUpState);
+  const [loginForm, setLoginForm] = useState(initialLoginState);
+  const [status, setStatus] = useState({ type: 'idle', message: '' });
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!initializing && user) {
+      navigate('/home', { replace: true });
+    }
+  }, [initializing, navigate, user]);
+
+  const activeForm = mode === 'signup' ? signUpForm : loginForm;
+
+  const updateForm = (field, value) => {
+    if (mode === 'signup') {
+      setSignUpForm((prev) => ({ ...prev, [field]: value }));
+    } else {
+      setLoginForm((prev) => ({ ...prev, [field]: value }));
+    }
+  };
+
+  const handleChange = (event) => {
+    const { name, value, type, checked } = event.target;
+    updateForm(name, type === 'checkbox' ? checked : value);
+  };
+
+  const switchMode = (nextMode) => {
+    setMode(nextMode);
+    setStatus({ type: 'idle', message: '' });
+    setSubmitting(false);
+  };
+
+  const statusClassName = useMemo(() => {
+    if (status.type === 'error') {
+      return 'landing__status landing__status--error';
+    }
+
+    if (status.type === 'success') {
+      return 'landing__status landing__status--success';
+    }
+
+    return 'landing__status';
+  }, [status.type]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    if (submitting) {
+      return;
+    }
+
+    if (!activeForm.acceptTerms) {
+      setStatus({ type: 'error', message: 'Please confirm you are at least 18 years old.' });
+      return;
+    }
+
+    setSubmitting(true);
+    setStatus({ type: 'loading', message: 'Processing your request…' });
+
+    try {
+      if (mode === 'signup') {
+        if (!signUpForm.displayName || !signUpForm.username || !signUpForm.email || !signUpForm.password) {
+          setStatus({ type: 'error', message: 'All fields are required to create your account.' });
+          setSubmitting(false);
+          return;
+        }
+
+        if (signUpForm.password.length < 8) {
+          setStatus({ type: 'error', message: 'Use a password with at least 8 characters.' });
+          setSubmitting(false);
+          return;
+        }
+
+        if (signUpForm.password !== signUpForm.confirmPassword) {
+          setStatus({ type: 'error', message: 'Passwords do not match.' });
+          setSubmitting(false);
+          return;
+        }
+
+        await signup({
+          displayName: signUpForm.displayName.trim(),
+          username: signUpForm.username.trim(),
+          email: signUpForm.email.trim(),
+          password: signUpForm.password
+        });
+        setStatus({ type: 'success', message: 'Account created! Redirecting to your feed…' });
+      } else {
+        if (!loginForm.identifier || !loginForm.password) {
+          setStatus({ type: 'error', message: 'Enter your email/username and password to continue.' });
+          setSubmitting(false);
+          return;
+        }
+
+        await login({
+          identifier: loginForm.identifier.trim(),
+          password: loginForm.password
+        });
+        setStatus({ type: 'success', message: 'Welcome back! Loading your feed…' });
+      }
+    } catch (error) {
+      const errorMessage = error?.details?.error || error?.message || 'Something went wrong. Please try again.';
+      setStatus({ type: 'error', message: errorMessage });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="landing">
+      <div className="landing__hero">
+        <div className="landing__brand">
+          <div className="landing__logo" aria-hidden="true">
+            <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="40" cy="40" r="36" fill="#0b1622" stroke="#00a3ff" strokeWidth="8" />
+              <path
+                d="M40 50c-6-4.4-12-8.8-12-16a8 8 0 0 1 15-3.4 8 8 0 0 1 15 3.4c0 7.2-6 11.6-12 16z"
+                fill="#00a3ff"
+              />
+            </svg>
+          </div>
+          <h1>FansET</h1>
+          <p>Built for creators who turn fandoms into thriving communities.</p>
+          <ul>
+            <li>
+              <span>✨</span>Smart discovery surfaces livestreams, drops, and collections you&apos;ll love.
+            </li>
+            <li>
+              <span>🗂️</span>Organize premium sets, workshops, and behind-the-scenes notes in one hub.
+            </li>
+            <li>
+              <span>🔒</span>Privacy-first infrastructure with token-based security for every action.
+            </li>
+          </ul>
         </div>
-        <h1>Fansly</h1>
-        <p>Not sure what you&apos;re into? We&apos;ll figure it out.</p>
-        <ul>
-          <li>
-            <span>⭐</span>Our algorithms find and filter content just for you.
-          </li>
-          <li>
-            <span>⭐</span>Swipe and discover your next favorite creator.
-          </li>
-          <li>
-            <span>⭐</span>Livestreaming, personal messaging, and more!
-          </li>
-        </ul>
+        <div className="landing__form" aria-live="polite">
+          <div className="landing__form-header">
+            <h2>{mode === 'signup' ? 'Create your FansET account' : 'Welcome back'}</h2>
+            <div className="landing__tabs" role="tablist" aria-label="Authentication mode">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={mode === 'signup'}
+                className={`landing__tab ${mode === 'signup' ? 'landing__tab--active' : ''}`}
+                onClick={() => switchMode('signup')}
+              >
+                Sign up
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={mode === 'login'}
+                className={`landing__tab ${mode === 'login' ? 'landing__tab--active' : ''}`}
+                onClick={() => switchMode('login')}
+              >
+                Log in
+              </button>
+            </div>
+          </div>
+          <form className="landing__fields" onSubmit={handleSubmit}>
+            {mode === 'signup' ? (
+              <>
+                <FormInput label="Display name">
+                  <input
+                    type="text"
+                    name="displayName"
+                    placeholder="Nova Kai"
+                    autoComplete="name"
+                    value={signUpForm.displayName}
+                    onChange={handleChange}
+                  />
+                </FormInput>
+                <FormInput label="Username" hint="Lowercase letters, numbers, and underscores">
+                  <input
+                    type="text"
+                    name="username"
+                    placeholder="novakai"
+                    autoComplete="username"
+                    value={signUpForm.username}
+                    onChange={handleChange}
+                  />
+                </FormInput>
+                <FormInput label="Email">
+                  <input
+                    type="email"
+                    name="email"
+                    placeholder="you@fanset.com"
+                    autoComplete="email"
+                    value={signUpForm.email}
+                    onChange={handleChange}
+                  />
+                </FormInput>
+                <FormInput label="Password" hint="Minimum 8 characters">
+                  <input
+                    type="password"
+                    name="password"
+                    placeholder="••••••••"
+                    autoComplete="new-password"
+                    value={signUpForm.password}
+                    onChange={handleChange}
+                  />
+                </FormInput>
+                <FormInput label="Confirm password">
+                  <input
+                    type="password"
+                    name="confirmPassword"
+                    placeholder="••••••••"
+                    autoComplete="new-password"
+                    value={signUpForm.confirmPassword}
+                    onChange={handleChange}
+                  />
+                </FormInput>
+              </>
+            ) : (
+              <>
+                <FormInput label="Email or username">
+                  <input
+                    type="text"
+                    name="identifier"
+                    placeholder="you@fanset.com or novakai"
+                    autoComplete="username"
+                    value={loginForm.identifier}
+                    onChange={handleChange}
+                  />
+                </FormInput>
+                <FormInput label="Password">
+                  <input
+                    type="password"
+                    name="password"
+                    placeholder="••••••••"
+                    autoComplete="current-password"
+                    value={loginForm.password}
+                    onChange={handleChange}
+                  />
+                </FormInput>
+              </>
+            )}
+
+            <label className="landing__checkbox">
+              <input
+                type="checkbox"
+                name="acceptTerms"
+                checked={activeForm.acceptTerms}
+                onChange={handleChange}
+              />
+              I confirm I am 18+ and agree to the FansET Terms &amp; Privacy Policy.
+            </label>
+
+            <button
+              type="submit"
+              className="landing__button landing__button--primary"
+              disabled={submitting}
+            >
+              {submitting ? 'Processing…' : mode === 'signup' ? 'Create account' : 'Log in'}
+            </button>
+          </form>
+
+          {status.message && <p className={statusClassName}>{status.message}</p>}
+
+          <div className="landing__social">
+            <button type="button" className="landing__social-button">
+              <span className="landing__icon">✖</span> Continue with X (Twitter)
+            </button>
+            <button type="button" className="landing__social-button">
+              <span className="landing__icon">🟦</span> Continue with Google
+            </button>
+            <button type="button" className="landing__social-button landing__social-button--twitch">
+              <span className="landing__icon">🎮</span> Continue with Twitch
+            </button>
+          </div>
+
+          <p className="landing__fine-print">
+            FansET is a subscription marketplace for adults. Payments are securely processed and your personal data is encrypted
+            in transit and at rest.
+          </p>
+        </div>
       </div>
-      <div className="landing__form">
-        <h2>Join the community</h2>
-        <div className="landing__actions">
-          <Link to="/home" className="landing__button landing__button--primary">
-            Sign up
-          </Link>
-          <Link to="/home" className="landing__button landing__button--outline">
-            Login
-          </Link>
+      <footer className="landing__footer">
+        <span>©2025 FansET</span>
+        <nav>
+          <a href="#">Explore FansET</a>
+          <a href="#">Become a Creator</a>
+          <a href="#">Support</a>
+          <a href="#">Community Guidelines</a>
+          <a href="#">Terms</a>
+          <a href="#">Privacy</a>
+          <a href="#">DMCA</a>
+        </nav>
+        <div className="landing__footer-meta">
+          <span role="img" aria-label="twitter">
+            🐦
+          </span>
+          <span role="img" aria-label="instagram">
+            📸
+          </span>
+          <select aria-label="language selection">
+            <option>English</option>
+            <option>Deutsch</option>
+            <option>日本語</option>
+          </select>
         </div>
-        <div className="landing__social">
-          <button type="button" className="landing__social-button">
-            <span className="landing__icon">✖</span> Sign in with Twitter
-          </button>
-          <button type="button" className="landing__social-button">
-            <span className="landing__icon">🟦</span> Sign in with Google
-          </button>
-          <button type="button" className="landing__social-button landing__social-button--twitch">
-            <span className="landing__icon">🎮</span> Sign in with Twitch
-          </button>
-        </div>
-        <label className="landing__checkbox">
-          <input type="checkbox" defaultChecked />I confirm that I am 18 years of age or older.
-        </label>
-        <p className="landing__fine-print">
-          By joining, you agree to our <a href="#">Terms &amp; Conditions</a> and <a href="#">Privacy Policy</a>. And
-          confirm that you are at least 18 years old.
-        </p>
-      </div>
+      </footer>
     </div>
-    <div className="landing__comparison">
-      <div className="landing__card">
-        <h3>OnlyFans style onboarding</h3>
-        <p>Sign up to support your favorite creators</p>
-        <form>
-          <label>
-            Email
-            <input type="email" placeholder="Email" />
-          </label>
-          <label>
-            Password
-            <input type="password" placeholder="Password" />
-          </label>
-          <label className="landing__checkbox landing__checkbox--inline">
-            <input type="checkbox" defaultChecked />I am 18+ and agree to the policies.
-          </label>
-          <button type="button" className="landing__button landing__button--ghost">
-            Log in
-          </button>
-        </form>
-        <div className="landing__social landing__social--compact">
-          <button type="button" className="landing__social-button">
-            ✖ Sign in with X
-          </button>
-          <button type="button" className="landing__social-button">
-            🟦 Sign in with Google
-          </button>
-          <button type="button" className="landing__social-button landing__social-button--green">
-            🔐 Passwordless sign in
-          </button>
-        </div>
-      </div>
-    </div>
-    <footer className="landing__footer">
-      <span>©2025 Fansly</span>
-      <nav>
-        <a href="#">Explore Fansly</a>
-        <a href="#">Become a Creator</a>
-        <a href="#">Contact Support</a>
-        <a href="#">Complaint Process</a>
-        <a href="#">Terms</a>
-        <a href="#">Privacy</a>
-        <a href="#">US 2257 DMCA</a>
-      </nav>
-      <div className="landing__footer-meta">
-        <span role="img" aria-label="twitter">
-          🐦
-        </span>
-        <span role="img" aria-label="instagram">
-          📸
-        </span>
-        <select aria-label="language selection">
-          <option>English</option>
-          <option>Deutsch</option>
-          <option>日本語</option>
-        </select>
-      </div>
-    </footer>
-  </div>
-);
+  );
+};
 
 export default LandingPage;

--- a/frontend/src/pages/MessagesPage.css
+++ b/frontend/src/pages/MessagesPage.css
@@ -14,8 +14,8 @@
 }
 
 .messages__tab--active {
-  border-color: var(--fansly-blue);
-  color: var(--fansly-blue);
+  border-color: var(--fanset-blue);
+  color: var(--fanset-blue);
 }
 
 .messages__search-pill {
@@ -37,7 +37,7 @@
   border: none;
   background: transparent;
   font-size: 1.25rem;
-  color: var(--fansly-blue);
+  color: var(--fanset-blue);
 }
 
 .messages__empty {

--- a/frontend/src/pages/NotificationsPage.css
+++ b/frontend/src/pages/NotificationsPage.css
@@ -25,8 +25,8 @@
 }
 
 .notifications__tab--active {
-  border-color: var(--fansly-blue);
-  color: var(--fansly-blue);
+  border-color: var(--fanset-blue);
+  color: var(--fanset-blue);
 }
 
 .notifications__icon {

--- a/frontend/src/pages/ProfilePage.css
+++ b/frontend/src/pages/ProfilePage.css
@@ -16,7 +16,7 @@
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #1d4ed8, var(--fansly-blue));
+  background: linear-gradient(135deg, #1d4ed8, var(--fanset-blue));
   color: #ffffff;
   display: grid;
   place-items: center;
@@ -92,7 +92,7 @@
   border-radius: 999px;
   padding: 0.85rem 1.75rem;
   border: none;
-  background: linear-gradient(135deg, var(--fansly-blue), #38bdf8);
+  background: linear-gradient(135deg, var(--fanset-blue), #38bdf8);
   color: #ffffff;
   font-weight: 600;
 }

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,59 +1,75 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Header from '../components/Header';
 import CreatorCard from '../components/CreatorCard';
 import { creators } from '../data/mockData';
+import useAuth from '../hooks/useAuth.js';
 import './ProfilePage.css';
 
-const ProfilePage = () => (
-  <div className="page profile">
-    <Header
-      title="< Surafel Teka"
-      subtitle="My profile"
-      searchPlaceholder="Search user's posts"
-      actions={
-        <button type="button" className="profile__spotify">
-          🎵 Sign in with Spotify
-        </button>
-      }
-    />
-    <section className="profile__banner">
-      <div className="profile__avatar">S</div>
-      <div className="profile__info">
-        <h2>Surafel Teka</h2>
-        <p>@u250973728 · Available</p>
-        <div className="profile__stats">
-          <span>0 Fans</span>
-          <span>0 Following</span>
+const getInitials = (value) =>
+  value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('')
+    .slice(0, 2) || 'FE';
+
+const ProfilePage = () => {
+  const { user } = useAuth();
+  const initials = useMemo(() => (user?.displayName ? getInitials(user.displayName) : 'FE'), [user?.displayName]);
+
+  return (
+    <div className="page profile">
+      <Header
+        title={`< ${user?.displayName || 'Your profile'}`}
+        subtitle={user?.username ? `@${user.username}` : 'My profile'}
+        searchPlaceholder="Search your posts"
+        actions={
+          <button type="button" className="profile__spotify">
+            🎵 Connect Spotify
+          </button>
+        }
+      />
+      <section className="profile__banner">
+        <div className="profile__avatar" aria-label="Profile avatar">
+          {initials}
         </div>
-      </div>
-      <button type="button" className="profile__edit">
-        ⚙ Edit profile
+        <div className="profile__info">
+          <h2>{user?.displayName || 'Your profile'}</h2>
+          <p>{user?.username ? `@${user.username}` : 'Complete your profile'} · Available</p>
+          <div className="profile__stats">
+            <span>0 Fans</span>
+            <span>0 Following</span>
+          </div>
+        </div>
+        <button type="button" className="profile__edit">
+          ⚙ Edit profile
+        </button>
+      </section>
+      <section className="profile__empty">
+        <div className="profile__empty-art" aria-hidden="true">
+          ◻ ◯ △
+        </div>
+        <h3>No posts</h3>
+        <p>Your media library is waiting for your first upload.</p>
+      </section>
+      <section className="profile__suggestions">
+        <h3>Discover creators</h3>
+        <div className="profile__suggestions-list">
+          {creators.map((creator) => (
+            <CreatorCard key={creator.id} creator={creator} />
+          ))}
+        </div>
+      </section>
+      <button type="button" className="profile__new-post">
+        + New post
       </button>
-    </section>
-    <section className="profile__empty">
-      <div className="profile__empty-art" aria-hidden="true">
-        ◻ ◯ △
+      <div className="profile__footer-links">
+        <a href="#">Privacy</a>
+        <a href="#">Cookie Notice</a>
+        <a href="#">Terms of Service</a>
       </div>
-      <h3>No posts</h3>
-      <p>Your media library is waiting for your first upload.</p>
-    </section>
-    <section className="profile__suggestions">
-      <h3>Discover creators</h3>
-      <div className="profile__suggestions-list">
-        {creators.map((creator) => (
-          <CreatorCard key={creator.id} creator={creator} />
-        ))}
-      </div>
-    </section>
-    <button type="button" className="profile__new-post">
-      + New post
-    </button>
-    <div className="profile__footer-links">
-      <a href="#">Privacy</a>
-      <a href="#">Cookie Notice</a>
-      <a href="#">Terms of Service</a>
     </div>
-  </div>
-);
+  );
+};
 
 export default ProfilePage;

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -1,0 +1,41 @@
+const normalizeEndpoint = (endpoint) => {
+  if (!endpoint) {
+    return '';
+  }
+
+  return endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
+};
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api').replace(/\/$/, '');
+
+export const apiClient = async (endpoint, { method = 'GET', data, token, headers, ...customConfig } = {}) => {
+  const config = {
+    method,
+    headers: {
+      ...(headers || {})
+    },
+    ...customConfig
+  };
+
+  if (data !== undefined) {
+    config.headers['Content-Type'] = 'application/json';
+    config.body = JSON.stringify(data);
+  }
+
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${API_BASE_URL}${normalizeEndpoint(endpoint)}`, config);
+  const isJson = response.headers.get('content-type')?.includes('application/json');
+  const payload = isJson ? await response.json() : null;
+
+  if (!response.ok) {
+    const error = new Error(payload?.error || 'Request failed');
+    error.status = response.status;
+    error.details = payload;
+    throw error;
+  }
+
+  return payload;
+};


### PR DESCRIPTION
## Summary
- restyle the landing page for the FansET brand and replace static buttons with real signup/login forms
- add a React auth context with protected routes and API client helpers so authenticated users can access the app shell
- implement Express JWT authentication routes plus content endpoints and document the new flows

## Testing
- npm run lint (frontend)
- npm run lint (backend)

------
https://chatgpt.com/codex/tasks/task_e_68cac6175ff0832690caca59191001a2